### PR TITLE
Updated slug name to use underscore

### DIFF
--- a/presence-monitor/config.json
+++ b/presence-monitor/config.json
@@ -1,7 +1,7 @@
 {
   "name": "Bluetooth Presence Monitor",
   "version": "dev",
-  "slug": "presence-monitor",
+  "slug": "presence_monitor",
   "description": "Passive Bluetooth presence detection of beacons, cell phones, and other Bluetooth devices.",
   "url": "https://github.com/Limych/addon-presence-monitor",
   "image": "limych/hassio-presence-monitor-{arch}",


### PR DESCRIPTION
Whenever i want to stop/start/restart the addon via the services hassio.addon_restart within home assistant i receive the following warning:

```
2020-01-22 12:42:46 ERROR (MainThread) [homeassistant.components.websocket_api.http.connection.1883485232] invalid slug bbd693f5_presence-monitor (try bbd693f5_presence_monitor) for dictionary value @ data['addon']

Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/components/websocket_api/commands.py", line 134, in handle_call_service
    connection.context(msg),
  File "/usr/src/homeassistant/homeassistant/core.py", line 1204, in async_call
    processed_data = handler.schema(service_data)
  File "/usr/local/lib/python3.7/site-packages/voluptuous/schema_builder.py", line 272, in __call__
    return self._compiled([], data)
  File "/usr/local/lib/python3.7/site-packages/voluptuous/schema_builder.py", line 594, in validate_dict
    return base_validate(path, iteritems(data), out)
  File "/usr/local/lib/python3.7/site-packages/voluptuous/schema_builder.py", line 432, in validate_mapping
    raise er.MultipleInvalid(errors)
voluptuous.error.MultipleInvalid: invalid slug bbd693f5_presence-monitor (try bbd693f5_presence_monitor) for dictionary value @ data['addon']
```

i think its related to the slug name.